### PR TITLE
Fix GitHub token in CI/CD script

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -22,7 +22,7 @@ elif [[ "$TRAVIS_BRANCH" == "develop" ]] && [[ "$TRAVIS_PULL_REQUEST" == "false"
     echo "|     Deploying latest on npm registry     |"
     echo "--------------------------------------------"
 
-    git remote set-url origin https://${GH_TOKEN}@github.com/capsulajs/capsulahub-core
+    git remote set-url origin https://${GH_ACCESS_TOKEN}@github.com/capsulajs/capsulahub-core
     git checkout develop
     lerna publish prerelease --dist-tag next --yes -m '[skip ci]'
 
@@ -36,7 +36,7 @@ elif [[ "$TRAVIS_BRANCH" == "master" ]] && [[ "$TRAVIS_PULL_REQUEST" == "false" 
     echo "|     Deploying stable on npm registry     |"
     echo "--------------------------------------------"
 
-    git remote set-url origin https://${GH_TOKEN}@github.com/capsulajs/capsulahub-core
+    git remote set-url origin https://${GH_ACCESS_TOKEN}@github.com/capsulajs/capsulahub-core
     git checkout master
     lerna publish patch --yes -m '[skip ci]'
 


### PR DESCRIPTION
Deploy is failing because variables are not defined with same name in Travis and in our script.

Update our script to use `GH_ACCESS_TOKEN` (instead of `GH_TOKEN`)